### PR TITLE
Fix: Tratamiento inseguro de las cookies

### DIFF
--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -21,7 +21,6 @@ public class Secure extends Controller {
         User u = User.loadUser(username);
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
             session.put("username", username);
-            session.put("password", password);
             Application.index();
         }else{
             flash.put("error", Messages.get("Public.login.error.credentials"));

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,9 +45,8 @@ http.port=9090
 # By default, session will be written to the transient PLAY_SESSION cookie.
 # The cookies are not secured by default, only set it to true
 # if you're serving your pages through https.
-# application.session.cookie=PLAY
-# application.session.maxAge=1h
-# application.session.secure=false
+application.session.secure=true
+application.session.httpOnly=true
 
 # Session/Cookie sharing between subdomain
 # ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Se corrigió la gestión insegura de la cookie de sesión identificada en #2.

Como parte del fix se realizaron las siguientes modificaciones:

* Se habilitó el atributo `HttpOnly` para la cookie de sesión, impidiendo el acceso a la misma mediante JavaScript desde el navegador y mitigando escenarios de robo de sesión vía XSS.
* Se habilitó el atributo `Secure`, asegurando que la cookie solo sea transmitida sobre conexiones HTTPS.
* Se eliminó el almacenamiento de la contraseña del usuario dentro de la sesión, la cual anteriormente quedaba expuesta en la cookie `PLAY_SESSION`.

<img width="1729" height="377" alt="Screenshot 2026-05-10 104138" src="https://github.com/user-attachments/assets/68fd2c15-f7b9-41bb-87f7-6c7aeb5f0822" />
<br/>

Respecto al atributo `SameSite`, Play1 no provee soporte nativo para su configuración directa. Sin embargo, los navegadores modernos aplican por defecto la política `SameSite=Lax` cuando el atributo no está presente, mitigando la mayoría de escenarios CSRF tradicionales.

Con estos cambios, la cookie de sesión deja de exponer credenciales sensibles y pasa a utilizar una configuración alineada con las prácticas recomendadas de hardening de aplicaciones web.