### PR TITLE
Fix CWE-20: valida rango de notas en backend y formulario

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -2,6 +2,7 @@ package controllers;
 
 import models.Constants;
 import models.User;
+import play.i18n.Messages;
 import play.mvc.*;
 
 import java.util.List;
@@ -57,6 +58,16 @@ public class Application extends Controller {
 
     public static void doSetMark(String student, Integer mark) {
         User u = User.loadUser(student);
+        if (u == null) {
+            notFound();
+        }
+
+        if (mark == null || mark < 0 || mark > 10) {
+            flash.error(Messages.get("Application.setMark.error.invalidRange"));
+            setMark(student);
+            return;
+        }
+
         u.setMark(mark);
         u.save();
         index();

--- a/app/views/Application/setMark.html
+++ b/app/views/Application/setMark.html
@@ -5,13 +5,17 @@
 
 <h3>Set mark for student: ${u.getUsername()}</h3>
 
+#{if flash.error}
+    <p class="error">&{flash.error}</p>
+#{/if}
+
 #{form @Application.doSetMark(u.getUsername())}
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
 
         <div class="form-group">
             <div class="input-icon">
-                <input class="form-control" type="text" placeholder="Mark (0-10)" id="mark" name="mark" />
+                <input class="form-control" type="number" min="0" max="10" step="1" required placeholder="Mark (0-10)" id="mark" name="mark" />
             </div>
         </div>
 

--- a/conf/messages
+++ b/conf/messages
@@ -24,3 +24,4 @@ Public.register.validation.name=Please enter a display name we can use to addres
 Public.register.validation.password=Please enter a password
 Public.register.validation.passwordConfirmation=Please confirm your password
 Public.register.validation.existingAccount=This account is already registered. Forgot your password?
+Application.setMark.error.invalidRange=Invalid mark. Allowed range is 0 to 10.


### PR DESCRIPTION
Se observa la vulnerabilidad reportada por el compañero Francisco Javier Vivancos Ortuño: ausencia de validación de entrada en la asignación de notas (CWE-20), donde el método doSetMark aceptaba valores fuera de la lógica de negocio y los persistía sin control.

Se añade el import de mensajes en app/controllers/Application.java para poder mostrar un error funcional al usuario cuando la nota enviada no es válida.

- Se valida que el alumno exista.
- Se valida en backend que la nota esté entre 0 y 10.
- Si el valor es inválido, no se guarda nada y se devuelve al formulario con error.
- Solo se persiste cuando la entrada cumple la regla de negocio.

Este bloque en app/views/Application/setMark.html muestra en pantalla el error funcional enviado desde el controlador cuando se intenta inyectar una nota inválida.

Se refuerza la validación de interfaz para guiar al usuario y reducir errores de entrada. Esta validación mejora UX, pero la protección real queda en backend