### PR TITLE
Fix CWE-20: validación de entrada en asignación de notas

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -2,6 +2,7 @@ package controllers;
 
 import models.Constants;
 import models.User;
+import play.i18n.Messages;
 import play.mvc.*;
 
 import java.util.List;
@@ -57,6 +58,16 @@ public class Application extends Controller {
 
     public static void doSetMark(String student, Integer mark) {
         User u = User.loadUser(student);
+        if (u == null) {
+            notFound();
+        }
+
+        if (mark == null || mark < 0 || mark > 10) {
+            flash.error(Messages.get("Application.setMark.error.invalidRange"));
+            setMark(student);
+            return;
+        }
+
         u.setMark(mark);
         u.save();
         index();

--- a/app/views/Application/setMark.html
+++ b/app/views/Application/setMark.html
@@ -5,13 +5,17 @@
 
 <h3>Set mark for student: ${u.getUsername()}</h3>
 
+#{if flash.error}
+    <p class="error">&{flash.error}</p>
+#{/if}
+
 #{form @Application.doSetMark(u.getUsername())}
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
 
         <div class="form-group">
             <div class="input-icon">
-                <input class="form-control" type="text" placeholder="Mark (0-10)" id="mark" name="mark" />
+                <input class="form-control" type="number" min="0" max="10" step="1" required placeholder="Mark (0-10)" id="mark" name="mark" />
             </div>
         </div>
 

--- a/conf/messages
+++ b/conf/messages
@@ -24,3 +24,4 @@ Public.register.validation.name=Please enter a display name we can use to addres
 Public.register.validation.password=Please enter a password
 Public.register.validation.passwordConfirmation=Please confirm your password
 Public.register.validation.existingAccount=This account is already registered. Forgot your password?
+Application.setMark.error.invalidRange=Invalid mark. Allowed range is 0 to 10.


### PR DESCRIPTION
Se observa que en la vulnerabilidad reportada por el compañero Francisco Javier Vivancos Ortuño, una ausencia de validación de entrada en la asignación de notas (CWE-20), donde el método doSetMark aceptaba valores fuera de la lógica de negocio y los persistía sin control.

Se añade el import de mensajes en app/controllers/Application.java para poder mostrar un error funcional al usuario cuando la nota enviada no es válida.
~~~diff
+ import play.i18n.Messages;

+ public static void doSetMark(String student, Integer mark) {
+     User u = User.loadUser(student);
+     if (u == null) {
+         notFound();
+     }
+ 
+     if (mark == null || mark < 0 || mark > 10) {
+         flash.error(Messages.get("Application.setMark.error.invalidRange"));
+         setMark(student);
+         return;
+     }
+ 
+     u.setMark(mark);
+     u.save();
+     index();
+ }
~~~

- Se valida que el alumno exista.
- Se valida en backend que la nota esté entre 0 y 10.
- Si el valor es inválido, no se guarda nada y se devuelve al formulario con error.
- Solo se persiste cuando la entrada cumple la regla de negocio.

Este bloque en app/views/Application/setMark.html muestra en pantalla el error funcional enviado desde el controlador cuando se intenta inyectar una nota inválida.
~~~diff
+  #{if flash.error}
+     <p class="error">&{flash.error}</p>
+  #{/if}
~~~
Se refuerza la validación de interfaz para guiar al usuario y reducir errores de entrada. Esta validación mejora UX, pero la protección real queda en el backend.
~~~diff
- <input class="form-control" type="text" placeholder="Mark (0-10)" id="mark" name="mark" />
+ <input class="form-control" type="number" min="0" max="10" step="1" required placeholder="Mark (0-10)" id="mark" name="mark" />
~~~
<img width="297" height="148" alt="image" src="https://github.com/user-attachments/assets/a4ef4f16-fe8b-4ca8-8427-7f16d35258b0" />

Se incorpora en conf/messages un mensaje reutilizable de validación para mantener consistencia con el sistema de internacionalización de la aplicación.
~~~diff
+ Application.setMark.error.invalidRange=Invalid mark. Allowed range is 0 to 10.
~~~
Por lo que al interceptar y reenviar una petición POST con mark=-20, la aplicación rechaza la entrada, muestra error y no persiste la calificación inválida.

Al reenviar la peticion con una nota negativa vemos que nos da error
<img width="546" height="125" alt="image" src="https://github.com/user-attachments/assets/4bf7044e-a747-4a29-951a-5879ed4f7e74" />
<img width="336" height="247" alt="image" src="https://github.com/user-attachments/assets/1f81b65e-461a-4aae-9932-07ffcf58ac40" />

