### PR TITLE
Fix: Exposición de credenciales

### DIFF
--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -5,6 +5,7 @@ import helpers.HashUtils;
 import models.User;
 import play.i18n.Messages;
 import play.mvc.Controller;
+import play.mvc.Http;
 
 public class Secure extends Controller {
 
@@ -18,6 +19,12 @@ public class Secure extends Controller {
     }
 
     public static void authenticate(String username, String password){
+        if (request.method.equals("GET")) {
+            badRequest(); 
+        }
+
+        checkAuthenticity();
+
         User u = User.loadUser(username);
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
             session.put("username", username);

--- a/app/views/Secure/login.html
+++ b/app/views/Secure/login.html
@@ -3,7 +3,10 @@
 <h2>&{'Public.login.title'}</h2>
 
 
-#{form @authenticate()}
+#{form @authenticate(), method:'POST'}
+    
+    #{authenticityToken /}
+    
     #{if flash.error}
         <p class="error">
             &{flash.error}

--- a/conf/routes
+++ b/conf/routes
@@ -8,7 +8,7 @@ GET     /remove/{student}                       Application.removeStudent
 GET     /setMark/{student}                      Application.setMark
 POST    /setMark/{student}                      Application.doSetMark
 GET     /login                                  Secure.login
-GET     /authenticate                           Secure.authenticate
+POST     /authenticate                          Secure.authenticate
 GET     /logout                                 Secure.logout
 GET     /register                               PublicContentBase.register
 POST    /register                               PublicContentBase.processRegister


### PR DESCRIPTION
Tratamiento de la vulnerabilidad identificada en #9.

Este fix corrige la exposición de credenciales en el login cambiando la petición de autenticación de GET a POST, evitando que el usuario y la contraseña aparezcan en la URL, el historial del navegador, logs de proxies y logs del servidor.

Además, se añadió protección CSRF utilizando los mecanismos authenticityToken y checkAuthenticity() de Play para asegurar que las peticiones de login provengan de la aplicación legítima.

El endpoint de autenticación ahora también rechaza explícitamente las peticiones GET.

Para despliegues en producción, se recomienda forzar el uso de HTTPS para garantizar que las credenciales viajen cifradas y reducir el riesgo de interceptación.