### PR TITLE
Fix: evitar sobrescritura de cuentas duplicadas en registro

### DIFF
--- a/app/controllers/PublicContentBase.java
+++ b/app/controllers/PublicContentBase.java
@@ -20,6 +20,12 @@ public class PublicContentBase extends Controller {
         return;
     }
 
+    if (User.loadUser(username) != null){
+        flash.error("El nombre de usuario ya existe");
+        register();
+        return;
+    }
+
     User u = new User(username, HashUtils.getMd5(password), type, -1);
     u.save();
     registerComplete();

--- a/app/views/PublicContentBase/register.html
+++ b/app/views/PublicContentBase/register.html
@@ -50,6 +50,12 @@
 <div id="register_error" class="error">${errors[0]}</div>
 #{/ifErrors}
 
+#{if flash.error}
+<p class="error">
+    &{flash.error}
+</p>
+#{/if}
+
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
 


### PR DESCRIPTION
Problema:
El endpoint "processRegister" no validaba si el username ya existía antes de crear la cuenta, permitiendo que cualquiera se registrara con un username existente y sobrescribiera la cuenta (contraseña y rol) de otro usuario (account takeover).

Solución:
Se añade una comprobación en "PublicContentBase.processRegister()"que verifica con "User.loadUser(username)" si ya existe un usuario con ese nombre, y si es así, se rechaza el registro mostrando un mensaje de error.
También se añadió el bloque de renderizado de "flash.error" en "register.html" (igual que ya existía en "login.html") para que el mensaje se muestre en pantalla.

Pruebas realizadas:
- Registro de un usuario nuevo: funciona correctamente.
- Registro de un username ya existente: se rechaza y se muestra el mensaje de error, sin sobrescribir la cuenta original.